### PR TITLE
fix(ui): display actual received amount equal to sent amount, do not …

### DIFF
--- a/packages/react-app/src/pages/bridge/index.js
+++ b/packages/react-app/src/pages/bridge/index.js
@@ -605,7 +605,8 @@ const BridgeIndex = () => {
             gasText = showGas.toFixed(18)
           }
           setGasFee(gasText)
-          setReceiveAmount(receiveAmount.div(1000000000000000000).toFixed(18))
+          //setReceiveAmount(receiveAmount.div(1000000000000000000).toFixed(18))
+          setReceiveAmount(inputAmount);
           console.log(`Estimate gas consume: ${gasPrice}`, gasPrice, receiveAmount);
         })
         .catch((error) => {
@@ -628,7 +629,8 @@ const BridgeIndex = () => {
           gasText = showGas.toFixed(18)
         }
         setGasFee(gasText)
-        setReceiveAmount(receiveAmount.div(1000000000000000000).toFixed(18))
+        //setReceiveAmount(receiveAmount.div(1000000000000000000).toFixed(18))
+        setReceiveAmount(inputAmount);
         console.log('====>', gasPrice, receiveAmount)
       })
     }

--- a/packages/react-app/src/pages/mobile/index.js
+++ b/packages/react-app/src/pages/mobile/index.js
@@ -480,7 +480,8 @@ const BridgeIndex = () => {
             gasText = showGas.toFixed(18)
           }
           setGasFee(gasText)
-          setReceiveAmount(receiveAmount.div(1000000000000000000).toFixed(18))
+          //setReceiveAmount(receiveAmount.div(1000000000000000000).toFixed(18))
+          setReceiveAmount(inputAmount);
           console.log(`Estimate gas consume: ${gasPrice}`, gasPrice, receiveAmount);
         })
         .catch((error) => {
@@ -503,7 +504,8 @@ const BridgeIndex = () => {
           gasText = showGas.toFixed(18)
         }
         setGasFee(gasText)
-        setReceiveAmount(receiveAmount.div(1000000000000000000).toFixed(18))
+        //setReceiveAmount(receiveAmount.div(1000000000000000000).toFixed(18))
+        setReceiveAmount(inputAmount)
         console.log('====>', gasPrice, receiveAmount)
       })
     }


### PR DESCRIPTION
…subtract gas fee in receive field

- Updated the receive amount calculation in the bridge page.
- The receive field now directly reflects the user input (send amount).
- Gas fee is displayed separately and no longer deducted from the receive amount.
- Ensures the UI matches the actual on-chain transfer behavior.